### PR TITLE
Fixxed incorrect generate_url function call

### DIFF
--- a/app/services/automation_service.py
+++ b/app/services/automation_service.py
@@ -99,7 +99,9 @@ class AutomationService:
                     "gitops.intended_exposed", "false"
                 )
 
-                url = generate_url(deployment_id, gitops_domain, True)
+                url = generate_url(
+                    self.workspace_name, deployment_id, gitops_domain, True
+                )
 
                 if label != "true":
                     url = None


### PR DESCRIPTION
This pull request modifies the `get_automations` method in `automation_service.py` to enhance the `generate_url` function call by including the `workspace_name` parameter.

* **Enhancement to `generate_url` function call**:
  - Updated the `generate_url` call in the `get_automations` method to include `self.workspace_name` as an additional parameter, improving the function's context and flexibility. (`[app/services/automation_service.pyL102-R104](diffhunk://#diff-01ee294a4500fafff5607151763582e6b358e102278d2bbe15e553705f00ec07L102-R104)`)