### PR TITLE
Keep old deployments

### DIFF
--- a/app/services/automation_service.py
+++ b/app/services/automation_service.py
@@ -172,14 +172,8 @@ class AutomationService:
                     "checksum": checksum,
                 }
             except Exception as e:
-                shutil.rmtree(output_dir, ignore_errors=True)
                 return {"error": f"Error processing file: {str(e)}"}
             finally:
-                if old_deploymend_checksum:
-                    shutil.rmtree(
-                        os.path.join(self.gitops_dir, old_deploymend_checksum),
-                        ignore_errors=True,
-                    )
                 os.unlink(temp_file.name)
 
     async def delete_automation(self, deployment_id: str):


### PR DESCRIPTION
Since the ability to roll back to previous deployments is a key feature of our system, we shouldn't delete them.

We should probably add a cleanup feature though, to get rid of stuff that's really old for disk space reasons.